### PR TITLE
Bump Maximum MTU to 9216

### DIFF
--- a/overlay/generic/lib/svc/method/net-physical
+++ b/overlay/generic/lib/svc/method/net-physical
@@ -108,13 +108,13 @@ function valid_mtu
 
     if ! [[ $mtu =~ [1-9][0-9][0-9][0-9] ]] ; then
         echo "Invalid mtu specified for tag $tag: $mtu"
-        echo "Valid MTU range is from 1500-9000"
+        echo "Valid MTU range is from 1500-9216"
         exit $SMF_EXIT_ERR_FATAL
     fi
 
-    if [[ $mtu -gt 9000 || $mtu -lt 1500 ]]; then
+    if [[ $mtu -gt 9216 || $mtu -lt 1500 ]]; then
         echo "Invalid mtu specified for tag $tag: $mtu"
-        echo "Valid MTU range is from 1500-9000"
+        echo "Valid MTU range is from 1500-9216"
         exit $SMF_EXIT_ERR_FATAL
     fi
 }


### PR DESCRIPTION
Modern 10Gbe and above adapters and network gear support larger MTUs than 9000.  This is important if users want to offer overlay networks of 9000 mtu, encapsulated in other protocols like vxlan, ipsec, vlan, etc.